### PR TITLE
Bump `pluginTimeout`, add logging to server

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -4,7 +4,13 @@ import * as fs from 'fs';
 import serve from 'fastify-static';
 import ms from 'ms';
 
-import underPressure from 'under-pressure';
+import underPressure, {
+  TYPE_EVENT_LOOP_DELAY,
+  TYPE_EVENT_LOOP_UTILIZATION,
+  TYPE_HEALTH_CHECK,
+  TYPE_HEAP_USED_BYTES,
+  TYPE_RSS_BYTES,
+} from 'under-pressure';
 import headers from './headers';
 import context from './context';
 
@@ -15,52 +21,86 @@ import apqWeather from '@trygql/apq-weather';
 import uploadsMock from '@trygql/uploads-mock';
 import webCollections from '@trygql/web-collections';
 
-const indexPath = path.join(process.cwd(), 'page/dist/index.html');
-const indexFile = fs.promises.readFile(indexPath);
+const bootApp = async () => {
+  const indexPath = path.join(process.cwd(), 'page/dist/index.html');
+  const indexFile = await fs.promises.readFile(indexPath);
 
-const app = Fastify({
-  logger: {
-    level: 'warn',
-  }
-});
-
-app.register(headers);
-app.register(context);
-app.register(underPressure, { maxEventLoopDelay: 1000 });
-
-app.register(basicPokedex);
-app.register(intermittentColors);
-app.register(relayNpm);
-app.register(apqWeather);
-app.register(uploadsMock);
-app.register(webCollections);
-
-app.get('/health', (_req, res) => {
-  res.code(200).send({ statusCode: 200, status: 'ok' });
-});
-
-app.get('/favicon.ico', (_req, res) => {
-  res.code(404).header('cache-control', 'max-age=604800').send();
-});
-
-app.get('/', async (_req, res) => {
-  res.code(200).type('text/html').send(await indexFile);
-});
-
-app.register(serve, {
-  root: path.join(process.cwd(), 'page/dist/assets/'),
-  prefix: '/assets/',
-  immutable: true,
-  maxAge: ms('7d'),
-});
-
-app.listen(process.env.PORT || 8080, '0.0.0.0')
-  .catch(error => {
-    if (error.errors) {
-      error.errors.forEach((error: Error) => console.error(error.toString()));
-    } else {
-      console.error(error.toString());
-    }
-
-    process.exit(1);
+  const app = Fastify({
+    logger: {
+      level: 'warn',
+    },
+    pluginTimeout: 2 * 60 * 1000, // 2 minutes
   });
+
+  app.register(headers);
+  app.register(context);
+  app.register(underPressure, {
+    maxEventLoopDelay: 1000,
+    pressureHandler: (req, rep, type, value) => {
+      switch (type) {
+        case TYPE_HEAP_USED_BYTES:
+          app.log.warn(`too many heap bytes used: ${value}`);
+          break;
+        case TYPE_RSS_BYTES:
+          app.log.warn(`too many rss bytes used: ${value}`);
+          break;
+        case TYPE_EVENT_LOOP_UTILIZATION:
+          app.log.warn(`too much event loop utilization: ${value}`);
+          break;
+        case TYPE_EVENT_LOOP_DELAY:
+          app.log.warn(`event loop delay exceeded threshold: ${value}`);
+          break;
+        case TYPE_HEALTH_CHECK:
+          app.log.warn(`failed health check`);
+          break;
+      }
+
+      rep.send('Whoops, out of memory');
+    },
+  });
+
+  app.register(basicPokedex);
+  app.register(intermittentColors);
+  app.register(relayNpm);
+  app.register(apqWeather);
+  app.register(uploadsMock);
+  app.register(webCollections);
+
+  app.get('/health', (_req, res) => {
+    res.code(200).send({ statusCode: 200, status: 'ok' });
+  });
+
+  app.get('/favicon.ico', (_req, res) => {
+    res.code(404).header('cache-control', 'max-age=604800').send();
+  });
+
+  app.get('/', async (_req, res) => {
+    res.code(200).type('text/html').send(indexFile);
+  });
+
+  app.register(serve, {
+    root: path.join(process.cwd(), 'page/dist/assets/'),
+    prefix: '/assets/',
+    immutable: true,
+    maxAge: ms('7d'),
+  });
+
+  app
+    .listen(process.env.PORT || 8080, '0.0.0.0')
+    .then(() => {
+      app.log.info(`App listening on port ${process.env.PORT || 8080}`);
+    })
+    .catch((error) => {
+      if (error.errors) {
+        error.errors.forEach((error: Error) => app.log.error(error.toString()));
+      } else {
+        app.log.error(error.toString());
+      }
+
+      process.exit(1);
+    });
+};
+
+bootApp().catch((err) => {
+  console.error(`App failed to start ${err}`);
+});


### PR DESCRIPTION
Addresses #4 

We're seeing the trygql instances fail regularly in Fly.io. The error I'm seeing in the dashboard is:

> Error: ERR_AVVIO_READY_TIMEOUT: plugin did not start in time: bound _encapsulateThreeParam. You may have forgotten to call 'done' function or to resolve a Promise

This appears to be related to [this issue](https://github.com/fastify/help/issues/188). 

This PR bumps the `pluginTimeout`, and also adds some additional logging to the server to (hopefully) help us further diagnose.